### PR TITLE
Add .git-blame-ignore-revs file containing format commits

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# scalafmt
+99d7bb1091f805c55a5c9fb8d4242d070f5c0895


### PR DESCRIPTION
Similar to pekko core, adds a `.git-blame-ignore-revs` which contains the hashes for the previous scalafmt commits.