### PR TITLE
Add .gitattributes to enforce unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Activate line ending normalization, setting eol will make the behavior match core.autocrlf = input
+* text=auto eol=lf
+# Force batch scripts to always use CRLF line endings
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Just like with other repos, adds `gitattributes` so that line endings are consistent.