### PR TITLE
scalatest 3.2.15

### DIFF
--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -28,5 +28,5 @@ lazy val `pekko-sample-cluster-client-grpc-scala` = project
       "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion,
       "org.apache.pekko" %% "pekko-discovery" % pekkoVersion,
       "org.apache.pekko" %% "pekko-multi-node-testkit" % pekkoVersion % Test,
-      "org.scalatest" %% "scalatest" % "3.1.1" % Test))
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test))
   .configs(MultiJvm)

--- a/pekko-sample-cluster-client-grpc-scala/src/multi-jvm/scala/sample/cluster/client/grpc/ClusterClientSpec.scala
+++ b/pekko-sample-cluster-client-grpc-scala/src/multi-jvm/scala/sample/cluster/client/grpc/ClusterClientSpec.scala
@@ -16,8 +16,8 @@ import org.apache.pekko.testkit._
 import org.apache.pekko.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 object ClusterClientSpec extends MultiNodeConfig {
   val client = role("client")
@@ -84,7 +84,7 @@ class ClusterClientMultiJvmNode5 extends ClusterClientSpec
 
 class ClusterClientSpec
     extends MultiNodeSpec(ClusterClientSpec)
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ImplicitSender {

--- a/pekko-sample-cluster-java/build.sbt
+++ b/pekko-sample-cluster-java/build.sbt
@@ -21,7 +21,7 @@ lazy val `pekko-sample-cluster-java` = project
       "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion,
       "ch.qos.logback" % "logback-classic" % "1.2.11",
       "org.apache.pekko" %% "pekko-multi-node-testkit" % pekkoVersion % Test,
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test),
     run / fork := false,
     Global / cancelable := false,

--- a/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -15,8 +15,8 @@ import org.apache.pekko.remote.testkit.MultiNodeConfig
 import org.apache.pekko.remote.testkit.MultiNodeSpec
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 
@@ -43,7 +43,7 @@ class StatsSampleSingleMasterSpecMultiJvmNode2 extends StatsSampleSingleMasterSp
 class StatsSampleSingleMasterSpecMultiJvmNode3 extends StatsSampleSingleMasterSpec
 
 abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSingleMasterSpecConfig)
-    with WordSpecLike with Matchers with BeforeAndAfterAll {
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   import StatsSampleSingleMasterSpecConfig._
 

--- a/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/pekko-sample-cluster-java/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -34,11 +34,11 @@ class StatsSampleSpecMultiJvmNode3 extends StatsSampleSpec
 import org.apache.pekko.remote.testkit.MultiNodeSpec
 import org.apache.pekko.testkit.ImplicitSender
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
-    with WordSpecLike with Matchers with BeforeAndAfterAll
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll
     with ImplicitSender {
 
   import StatsSampleSpecConfig._

--- a/pekko-sample-cluster-scala/build.sbt
+++ b/pekko-sample-cluster-scala/build.sbt
@@ -21,7 +21,7 @@ lazy val `pekko-sample-cluster-scala` = project
       "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion,
       "ch.qos.logback" % "logback-classic" % "1.2.11",
       "org.apache.pekko" %% "pekko-multi-node-testkit" % pekkoVersion % Test,
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test),
     run / fork := false,
     Global / cancelable := false,

--- a/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
+++ b/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSingleMasterSpec.scala
@@ -21,8 +21,8 @@ import org.apache.pekko.testkit.ImplicitSender
 import org.apache.pekko.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -51,7 +51,7 @@ class StatsSampleSingleMasterSpecMultiJvmNode2 extends StatsSampleSingleMasterSp
 class StatsSampleSingleMasterSpecMultiJvmNode3 extends StatsSampleSingleMasterSpec
 
 abstract class StatsSampleSingleMasterSpec extends MultiNodeSpec(StatsSampleSingleMasterSpecConfig)
-    with WordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll with ImplicitSender {
 
   import StatsSampleSingleMasterSpecConfig._
 

--- a/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
+++ b/pekko-sample-cluster-scala/src/multi-jvm/scala/sample/cluster/stats/StatsSampleSpec.scala
@@ -42,11 +42,11 @@ class StatsSampleSpecMultiJvmNode3 extends StatsSampleSpec
 import org.apache.pekko.remote.testkit.MultiNodeSpec
 import org.apache.pekko.testkit.ImplicitSender
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.Matchers
-import org.scalatest.WordSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class StatsSampleSpec extends MultiNodeSpec(StatsSampleSpecConfig)
-    with WordSpecLike with Matchers with BeforeAndAfterAll
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll
     with ImplicitSender {
 
   import StatsSampleSpecConfig._

--- a/pekko-sample-distributed-data-java/build.sbt
+++ b/pekko-sample-distributed-data-java/build.sbt
@@ -22,7 +22,7 @@ val `pekko-sample-distributed-data-java` = project
       "org.apache.pekko" %% "pekko-multi-node-testkit" % pekkoVersion % Test,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,
       "ch.qos.logback" % "logback-classic" % "1.2.11" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test),
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test),
     run / fork := true,
     Global / cancelable := false, // ctrl-c
     // disable parallel tests

--- a/pekko-sample-distributed-data-java/src/multi-jvm/scala/sample/distributeddata/STMultiNodeSpec.scala
+++ b/pekko-sample-distributed-data-java/src/multi-jvm/scala/sample/distributeddata/STMultiNodeSpec.scala
@@ -1,15 +1,15 @@
 package sample.distributeddata
 
 import org.apache.pekko.remote.testkit.MultiNodeSpecCallbacks
-
-import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
-import org.scalatest.Matchers
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 /**
  * Hooks up MultiNodeSpec with ScalaTest
  */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-    with WordSpecLike with Matchers with BeforeAndAfterAll {
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 

--- a/pekko-sample-distributed-data-scala/build.sbt
+++ b/pekko-sample-distributed-data-scala/build.sbt
@@ -22,7 +22,7 @@ val `pekko-sample-distributed-data-scala` = project
       "org.apache.pekko" %% "pekko-multi-node-testkit" % pekkoVersion % Test,
       "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,
       "ch.qos.logback" % "logback-classic" % "1.2.11" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test),
+      "org.scalatest" %% "scalatest" % "3.2.15" % Test),
     run / fork := true,
     Global / cancelable := false, // ctrl-c
     // disable parallel tests

--- a/pekko-sample-distributed-data-scala/src/multi-jvm/scala/sample/distributeddata/STMultiNodeSpec.scala
+++ b/pekko-sample-distributed-data-scala/src/multi-jvm/scala/sample/distributeddata/STMultiNodeSpec.scala
@@ -2,14 +2,15 @@ package sample.distributeddata
 
 import org.apache.pekko.remote.testkit.MultiNodeSpecCallbacks
 
-import org.scalatest.{ BeforeAndAfterAll, WordSpecLike }
-import org.scalatest.Matchers
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 /**
  * Hooks up MultiNodeSpec with ScalaTest
  */
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
-    with WordSpecLike with Matchers with BeforeAndAfterAll {
+    with AnyWordSpecLike with Matchers with BeforeAndAfterAll {
 
   override def beforeAll() = multiNodeSpecBeforeAll()
 

--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -23,5 +23,5 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.11",
   // test dependencies
   "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test,
   "commons-io" % "commons-io" % "2.11.0" % Test)

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -59,7 +59,7 @@ lazy val processor = project
     "org.apache.pekko" %% "pekko-http-spray-json" % pekkoHttpVersion,
     "ch.qos.logback" % "logback-classic" % LogbackVersion,
     "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test))
+    "org.scalatest" %% "scalatest" % "3.2.15" % Test))
 
 lazy val producer = project
   .in(file("producer"))
@@ -68,4 +68,4 @@ lazy val producer = project
     "org.apache.pekko" %% "pekko-connectors-kafka" % pekkoConnectorsKafkaVersion,
     "org.apache.pekko" %% "pekko-stream" % pekkoVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.11",
-    "org.scalatest" %% "scalatest" % "3.0.8" % Test))
+    "org.scalatest" %% "scalatest" % "3.2.15" % Test))

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -24,7 +24,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.11",
   "org.apache.pekko" %% "pekko-persistence-cassandra-launcher" % cassandraPluginVersion,
   "org.apache.pekko" %% "pekko-persistence-testkit" % pekkoVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test)
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test)
 
 // transitive dependency of akka 2.5x that is brought in by addons but evicted
 dependencyOverrides += "org.apache.pekko" %% "pekko-protobuf" % pekkoVersion

--- a/pekko-sample-persistence-scala/build.sbt
+++ b/pekko-sample-persistence-scala/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-serialization-jackson" % pekkoVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.11",
   "org.apache.pekko" %% "pekko-actor-testkit-typed" % pekkoVersion % Test,
-  "org.scalatest" %% "scalatest" % "3.1.0" % Test)
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test)
 
 Compile / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint")
 


### PR DESCRIPTION
* seems tidier to use same version of scalatest in all the samples
* if we're changing, we might as well use latest version of scalatest