### PR TITLE
#35 : Use pekko paradox

### DIFF
--- a/docs-gen/project/PekkoSamplePlugin.scala
+++ b/docs-gen/project/PekkoSamplePlugin.scala
@@ -23,9 +23,7 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
 
   val propertiesSettings = Seq(
     Compile / paradoxProperties ++= Map(
-      "download_url" -> s"https://example.lightbend.com/v1/download/${templateName.value}"
-    )
-  )
+      "download_url" -> s"https://example.lightbend.com/v1/download/${templateName.value}"))
 
   val sourceDirectorySettings = Seq(
     bodyPrefix := s"""${name.value}
@@ -52,15 +50,14 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
         IO.copyDirectory(inDir / "tutorial", outDir / "tutorial")
       }
       outDir
-    }
-  )
+    })
 
   override def projectSettings: Seq[Setting[_]] =
-   themeSettings ++
-   propertiesSettings ++
-   sourceDirectorySettings ++
-   Seq(
-    baseUrl := "https://github.com/apache/incubator-pekko-samples/current",
-    crossPaths := false,
-    templateName := baseProject.value.replaceAll("-sample-", "-samples-"))
+    themeSettings ++
+    propertiesSettings ++
+    sourceDirectorySettings ++
+    Seq(
+      baseUrl := "https://github.com/apache/incubator-pekko-samples/current",
+      crossPaths := false,
+      templateName := baseProject.value.replaceAll("-sample-", "-samples-"))
 }

--- a/docs-gen/project/PekkoSamplePlugin.scala
+++ b/docs-gen/project/PekkoSamplePlugin.scala
@@ -16,6 +16,11 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
   }
   import autoImport._
 
+  val themeSettings = Seq(
+    // allow access to snapshots for pekko-sbt-paradox
+    resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/"),
+    pekkoParadoxGithub := Some("https://github.com/apache/incubator-pekko"))
+
   val propertiesSettings = Seq(
     Compile / paradoxProperties ++= Map(
       "download_url" -> s"https://example.lightbend.com/v1/download/${templateName.value}"
@@ -51,6 +56,7 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
   )
 
   override def projectSettings: Seq[Setting[_]] =
+   themeSettings ++
    propertiesSettings ++
    sourceDirectorySettings ++
    Seq(

--- a/docs-gen/project/PekkoSamplePlugin.scala
+++ b/docs-gen/project/PekkoSamplePlugin.scala
@@ -1,10 +1,11 @@
 import sbt._
 import Keys._
-import com.lightbend.paradox.sbt.ParadoxPlugin
+import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
 import org.apache.pekko.PekkoParadoxPlugin
+import org.apache.pekko.PekkoParadoxPlugin.autoImport._
 
 object PekkoSamplePlugin extends sbt.AutoPlugin {
-  override def requires = ParadoxPlugin
+  override def requires = PekkoParadoxPlugin
   override def trigger = allRequirements
   object autoImport {
     val baseUrl = settingKey[String]("")
@@ -14,7 +15,6 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
     val bodyTransformation = settingKey[String => String]("")
   }
   import autoImport._
-  import ParadoxPlugin.autoImport._
   override def projectSettings: Seq[Setting[_]] = Seq(
     baseUrl := "https://github.com/apache/incubator-pekko-samples/tree/main",
     crossPaths := false,

--- a/docs-gen/project/plugins.sbt
+++ b/docs-gen/project/plugins.sbt
@@ -1,8 +1,4 @@
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
-// We have to deliberately use older versions of sbt-paradox because current Pekko sbt build
-// only loads on JDK 1.8 so we need to bring in older versions of parboiled which support JDK 1.8
-addSbtPlugin(("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+30-8bee46d0-SNAPSHOT").excludeAll(
-  "com.lightbend.paradox", "sbt-paradox"))
-addSbtPlugin(("com.lightbend.paradox" % "sbt-paradox" % "0.9.2").force())
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+30-8bee46d0-SNAPSHOT")

--- a/docs-gen/project/plugins.sbt
+++ b/docs-gen/project/plugins.sbt
@@ -1,4 +1,4 @@
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
-addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+30-8bee46d0-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+39-1df580ce-SNAPSHOT")


### PR DESCRIPTION
Fixes #35 

tested locally - success:
```
sbt paradox
start pekko-sample-cluster-scala/target/paradox/site/main/index.html
```
![image](https://user-images.githubusercontent.com/43856946/234264980-20affbb6-b57f-4bc1-8030-760ea6483579.png)

I've also reformatted the input to projectSettings so that they're easier to interpret