### PR TITLE
fix job name in publish-nightly.yml

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Publish Nightly
 
 on:
   schedule:


### PR DESCRIPTION
Name is a copy of the name used in another job - so it is good to fix the name to something more appropriate.