### PR TITLE
update sbt and use pekko 1.0.0 in samples with no downstream pekko deps

### DIFF
--- a/docs-gen/project/build.properties
+++ b/docs-gen/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/docs-gen/project/plugins.sbt
+++ b/docs-gen/project/plugins.sbt
@@ -1,4 +1,4 @@
 // allow access to snapshots for pekko-sbt-paradox
 resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
-addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+39-1df580ce-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+43-d9643c78-SNAPSHOT")

--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -1,10 +1,7 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+val pekkoVersion = "1.0.0"
 
 lazy val `pekko-sample-cluster-client-grpc-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -1,7 +1,10 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "1.0.0"
+val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+
+// allow access to snapshots
+resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
 lazy val `pekko-sample-cluster-client-grpc-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-client-grpc-scala/project/build.properties
+++ b/pekko-sample-cluster-client-grpc-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-cluster-docker-compose-java/build.sbt
+++ b/pekko-sample-cluster-docker-compose-java/build.sbt
@@ -10,17 +10,14 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
 /* dependencies */
 libraryDependencies ++= Seq(
   // -- Logging --
   "ch.qos.logback" % "logback-classic" % logbackVersion,
-  // -- Akka --
+  // -- Pekko --
   "org.apache.pekko" %% "pekko-actor-typed" % pekkoVersion,
   "org.apache.pekko" %% "pekko-cluster-typed" % pekkoVersion)
 

--- a/pekko-sample-cluster-docker-compose-java/project/build.properties
+++ b/pekko-sample-cluster-docker-compose-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-cluster-docker-compose-scala/build.sbt
+++ b/pekko-sample-cluster-docker-compose-scala/build.sbt
@@ -11,11 +11,8 @@ scalacOptions ++= Seq(
   "-encoding", "UTF-8",
   "-Xlint")
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
 
 /* dependencies */
 libraryDependencies ++= Seq(

--- a/pekko-sample-cluster-docker-compose-scala/project/build.properties
+++ b/pekko-sample-cluster-docker-compose-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-cluster-java/build.sbt
+++ b/pekko-sample-cluster-java/build.sbt
@@ -1,11 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 lazy val `pekko-sample-cluster-java` = project
   .in(file("."))

--- a/pekko-sample-cluster-java/pom.xml
+++ b/pekko-sample-cluster-java/pom.xml
@@ -11,7 +11,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pekko.version>0.0.0+26669-ec5b6764-SNAPSHOT</pekko.version>
+    <pekko.version>1.0.0</pekko.version>
   </properties>
 
   <dependencies>

--- a/pekko-sample-cluster-java/project/build.properties
+++ b/pekko-sample-cluster-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-cluster-kubernetes-scala/project/build.properties
+++ b/pekko-sample-cluster-kubernetes-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-cluster-scala/build.sbt
+++ b/pekko-sample-cluster-scala/build.sbt
@@ -1,11 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 lazy val `pekko-sample-cluster-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-scala/project/build.properties
+++ b/pekko-sample-cluster-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-distributed-data-java/build.sbt
+++ b/pekko-sample-distributed-data-java/build.sbt
@@ -1,11 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 val `pekko-sample-distributed-data-java` = project
   .in(file("."))

--- a/pekko-sample-distributed-data-java/project/build.properties
+++ b/pekko-sample-distributed-data-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-distributed-data-scala/build.sbt
+++ b/pekko-sample-distributed-data-scala/build.sbt
@@ -1,11 +1,8 @@
 import com.typesafe.sbt.SbtMultiJvm.multiJvmSettings
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 val `pekko-sample-distributed-data-scala` = project
   .in(file("."))

--- a/pekko-sample-distributed-data-scala/project/build.properties
+++ b/pekko-sample-distributed-data-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-distributed-workers-scala/project/build.properties
+++ b/pekko-sample-distributed-workers-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-fsm-java/pom.xml
+++ b/pekko-sample-fsm-java/pom.xml
@@ -6,25 +6,13 @@
 
   <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <pekko.version>0.0.0+26669-ec5b6764-SNAPSHOT</pekko.version>
+      <pekko.version>1.0.0</pekko.version>
   </properties>
 
   <groupId>org.apache.pekko</groupId>
   <artifactId>pekko-sample-fsm-java</artifactId>
   <packaging>jar</packaging>
   <version>1.0</version>
-
-  <repositories>
-      <repository>
-      <id>apache-pekko-snapshots</id>
-      <name>Apache Snapshots Repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      <layout>default</layout>
-      <snapshots>
-          <enabled>true</enabled>
-      </snapshots>
-      </repository>
-  </repositories>
 
   <dependencies>
     <dependency>

--- a/pekko-sample-fsm-scala/build.sbt
+++ b/pekko-sample-fsm-scala/build.sbt
@@ -1,11 +1,8 @@
 organization := "org.apache.pekko"
 name := "pekko-sample-fsm-scala"
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 scalaVersion := "2.13.11"
 libraryDependencies ++= Seq(

--- a/pekko-sample-fsm-scala/project/build.properties
+++ b/pekko-sample-fsm-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-kafka-to-sharding-scala/project/build.properties
+++ b/pekko-sample-kafka-to-sharding-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-   <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
   <artifactId>pekko-sample-replicated-event-sourcing-java</artifactId>
   <groupId>org.apache.pekko</groupId>
   <name>Apache Pekko replicated event sourcing multi dc sample</name>

--- a/pekko-sample-persistence-dc-scala/project/build.properties
+++ b/pekko-sample-persistence-dc-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-persistence-java/pom.xml
+++ b/pekko-sample-persistence-java/pom.xml
@@ -16,21 +16,9 @@
         </license>
     </licenses>
 
-    <repositories>
-        <repository>
-        <id>apache-pekko-snapshots</id>
-        <name>Apache Snapshots Repository</name>
-        <url>https://repository.apache.org/content/repositories/snapshots/</url>
-        <layout>default</layout>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-        </repository>
-    </repositories>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <pekko.version>0.0.0+26669-ec5b6764-SNAPSHOT</pekko.version>
+        <pekko.version>1.0.0</pekko.version>
     </properties>
 
     <dependencies>

--- a/pekko-sample-persistence-scala/build.sbt
+++ b/pekko-sample-persistence-scala/build.sbt
@@ -2,11 +2,8 @@ organization := "org.apache.pekko"
 name := "pekko-sample-persistence-scala"
 
 scalaVersion := "2.13.11"
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
+val pekkoVersion = "1.0.0"
 val logbackVersion = "1.2.12"
-
-// allow access to snapshots
-resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-persistence-typed" % pekkoVersion,

--- a/pekko-sample-persistence-scala/project/build.properties
+++ b/pekko-sample-persistence-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-sharding-java/project/build.properties
+++ b/pekko-sample-sharding-java/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2

--- a/pekko-sample-sharding-scala/project/build.properties
+++ b/pekko-sample-sharding-scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.2


### PR DESCRIPTION
* will come back to other samples and update pekko when we have new snapshots for pekko-http/pekko-management/etc that have pekko 1.0.0 dependency 