### PR TITLE
more updates to use pekko 1.0.0

### DIFF
--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -3,8 +3,8 @@ name := "pekko-distributed-workers"
 version := "1.0"
 
 scalaVersion := "2.13.11"
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
-val cassandraPluginVersion = "0.0.0-1095-5ca43b58-SNAPSHOT"
+val pekkoVersion = "1.0.0"
+val cassandraPluginVersion = "0.0.0-1102-939e199d-SNAPSHOT"
 val logbackVersion = "1.2.12"
 
 // allow access to snapshots

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -31,7 +31,7 @@
    <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <pekko.version>1.0.0</pekko.version>
-    <pekko-persistence-cassandra.version>0.0.0-1095-5ca43b58-SNAPSHOT</pekko-persistence-cassandra.version>
+    <pekko-persistence-cassandra.version>0.0.0-1102-939e199d-SNAPSHOT</pekko-persistence-cassandra.version>
     <pekko-http.version>0.0.0+4468-963bd592-SNAPSHOT</pekko-http.version>
     <pekko-management.version>0.0.0+757-f7d48cde-SNAPSHOT</pekko-management.version>
   </properties>

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -3,11 +3,11 @@ name := "pekko-sample-replicated-event-sourcing-scala"
 
 scalaVersion := "2.13.11"
 
-val pekkoVersion = "0.0.0+26669-ec5b6764-SNAPSHOT"
-val cassandraPluginVersion = "0.0.0-1095-5ca43b58-SNAPSHOT"
+val pekkoVersion = "1.0.0"
+val cassandraPluginVersion = "0.0.0-1102-939e199d-SNAPSHOT"
 
-val pekkoHttpVersion = "0.0.0+4411-6fe04045-SNAPSHOT"
-val pekkoClusterManagementVersion = "0.0.0+752-95cdd415-SNAPSHOT"
+val pekkoHttpVersion = "0.0.0+4468-963bd592-SNAPSHOT"
+val pekkoClusterManagementVersion = "0.0.0+757-f7d48cde-SNAPSHOT"
 
 val logbackVersion = "1.2.12"
 


### PR DESCRIPTION
* final samples upgraded to pekko 1.0.0
* had to wait for the persistence-cassandra snapshot that uses pekko 1.0.0 to be ready