### PR TITLE
Changed the module name to include suffix -scala

### DIFF
--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -1,4 +1,4 @@
-name := "pekko-distributed-workers"
+name := "pekko-distributed-workers-scala"
 
 version := "1.0"
 


### PR DESCRIPTION
 The module name now is: 
```scala
name := "pekko-distributed-workers-scala"
```
Instead of:
```scala
name := "pekko-distributed-workers"
```