### PR TITLE
upgrade pekko snapshots

### DIFF
--- a/docs-gen/project/PekkoSamplePlugin.scala
+++ b/docs-gen/project/PekkoSamplePlugin.scala
@@ -18,7 +18,7 @@ object PekkoSamplePlugin extends sbt.AutoPlugin {
 
   val themeSettings = Seq(
     // allow access to snapshots for pekko-sbt-paradox
-    resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/"),
+    resolvers += Resolver.ApacheMavenSnapshotsRepo,
     pekkoParadoxGithub := Some("https://github.com/apache/incubator-pekko"))
 
   val propertiesSettings = Seq(

--- a/docs-gen/project/plugins.sbt
+++ b/docs-gen/project/plugins.sbt
@@ -1,4 +1,4 @@
 // allow access to snapshots for pekko-sbt-paradox
-resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 addSbtPlugin("org.apache.pekko" % "pekko-sbt-paradox" % "0.0.0+56-bff08336-SNAPSHOT")

--- a/pekko-sample-cluster-client-grpc-scala/build.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/build.sbt
@@ -4,7 +4,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 val pekkoVersion = "1.0.1"
 
 // allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 lazy val `pekko-sample-cluster-client-grpc-scala` = project
   .in(file("."))

--- a/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
+++ b/pekko-sample-cluster-client-grpc-scala/project/plugins.sbt
@@ -1,5 +1,5 @@
 // allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-73-c03eff2b-SNAPSHOT")
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4")

--- a/pekko-sample-cluster-kubernetes-scala/build.sbt
+++ b/pekko-sample-cluster-kubernetes-scala/build.sbt
@@ -9,7 +9,7 @@ val pekkoManagementVersion = "1.0.0-RC1+1-15f8c323-SNAPSHOT"
 val logbackVersion = "1.2.12"
 
 // allow access to snapshots
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 // make version compatible with docker for publishing
 ThisBuild / dynverSeparator := "-"

--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -8,7 +8,7 @@ val cassandraPluginVersion = "0.0.0-1102-939e199d-SNAPSHOT"
 val logbackVersion = "1.2.12"
 
 // allow access to snapshots
-resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 Global / cancelable := false
 

--- a/pekko-sample-kafka-to-sharding-scala/build.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / Test / testOptions += Tests.Argument("-oDF")
 ThisBuild / licenses := Seq(("CC0", url("http://creativecommons.org/publicdomain/zero/1.0")))
 
 // allow access to snapshots
-ThisBuild / resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 Global / cancelable := true // ctrl-c
 

--- a/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
+++ b/pekko-sample-kafka-to-sharding-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 addSbtPlugin("org.apache.pekko" % "sbt-pekko-grpc" % "0.0.0-73-c03eff2b-SNAPSHOT")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-javaagent" % "0.1.4") // ALPN agent

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -4,15 +4,15 @@ name := "pekko-sample-replicated-event-sourcing-scala"
 scalaVersion := "2.13.11"
 
 val pekkoVersion = "1.0.1"
-val cassandraPluginVersion = "0.0.0-1102-939e199d-SNAPSHOT"
+val cassandraPluginVersion = "0.0.0-1110-6b7494d3-SNAPSHOT"
 
-val pekkoHttpVersion = "0.0.0+4468-963bd592-SNAPSHOT"
-val pekkoClusterManagementVersion = "0.0.0+757-f7d48cde-SNAPSHOT"
+val pekkoHttpVersion = "1.0.0"
+val pekkoClusterManagementVersion = "1.0.0-RC1+1-15f8c323-SNAPSHOT"
 
 val logbackVersion = "1.2.12"
 
 // allow access to snapshots
-resolvers += "Apache Nexus Snapshots".at("https://repository.apache.org/content/groups/snapshots/")
+resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 libraryDependencies ++= Seq(
   "org.apache.pekko" %% "pekko-cluster-sharding-typed" % pekkoVersion,


### PR DESCRIPTION
* use sbt Resolver.ApacheMavenSnapshotsRepo
* last set of jar upgrades associated with pekko-http and pekko-connectors-kafka releases