### PR TITLE
Feature/missing workresults actor

### DIFF
--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/Main.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/Main.scala
@@ -40,7 +40,7 @@ object Main {
   }
 
   def startClusterInSameJvm(): Unit = {
-    //startCassandraDatabase()
+    startCassandraDatabase()
     // two backend nodes
     start(7345, "back-end")
     start(7355, "back-end")

--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManager.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManager.scala
@@ -119,6 +119,8 @@ object WorkManager {
           // Any in progress work from the previous incarnation is retried
           ctx.self ! ResetWorkInProgress
       }
+      // Publish events to the system event stream as PublishedEvent after they have been persisted
+        .withEventPublishing(enabled = true)
     }
 
 }

--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkResultConsumerActor.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkResultConsumerActor.scala
@@ -1,0 +1,24 @@
+package worker
+
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
+import org.apache.pekko.persistence.typed.PublishedEvent
+
+object WorkResultConsumerActor {
+  def apply(): Behavior[PublishedEvent] =
+    Behaviors.setup { context =>
+      context.log.info("WorkResultConsumerActor started")
+
+      Behaviors.receiveMessage { message =>
+        handleReceivedEvent(context, message)
+        Behaviors.same
+      }
+    }
+
+  private def handleReceivedEvent(context: ActorContext[PublishedEvent], event: PublishedEvent): Unit = {
+    event.event match {
+      case WorkState.WorkInProgressReset | WorkState.WorkCompleted | WorkState.WorkStarted | WorkState.WorkAccepted =>
+        context.log.info(s"Received published event [${event.event.getClass.getCanonicalName}]: {}", event)
+    }
+  }
+}


### PR DESCRIPTION
The README.md file mentions and non-existing `WorkResultConsumerActor` that consumes results and logs them.
I have created this actor that consumes the events generated by the WorkManager:
```scala
.withEventPublishing(enabled = true)
```
