### PR TITLE
Created WorkResultConsumerActor for handling published events

### DIFF
--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/Main.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/Main.scala
@@ -2,12 +2,12 @@ package worker
 
 import java.io.File
 import java.util.concurrent.CountDownLatch
-
 import org.apache.pekko.actor.typed.ActorSystem
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.scaladsl.{ ActorContext, Behaviors }
 import org.apache.pekko.cluster.typed.Cluster
 import org.apache.pekko.persistence.cassandra.testkit.CassandraLauncher
 import com.typesafe.config.{ Config, ConfigFactory }
+import org.apache.pekko.actor.typed.eventstream.EventStream
 import org.apache.pekko.cluster.typed.SelfUp
 import org.apache.pekko.cluster.typed.Subscribe
 
@@ -39,6 +39,11 @@ object Main {
     }
   }
 
+  private def createWorkResultsConsumer(ctx: ActorContext[SelfUp]): Unit = {
+    val eventListener = ctx.spawn(WorkResultConsumerActor(), "work-consumer-actor")
+    ctx.system.eventStream ! EventStream.Subscribe(eventListener)
+  }
+
   def startClusterInSameJvm(): Unit = {
     startCassandraDatabase()
     // two backend nodes
@@ -57,6 +62,7 @@ object Main {
       Behaviors.setup[SelfUp](ctx => {
         val cluster = Cluster(ctx.system)
         cluster.subscriptions ! Subscribe(ctx.self, classOf[SelfUp])
+        createWorkResultsConsumer(ctx)
         Behaviors.receiveMessage {
           case SelfUp(_) =>
             ctx.log.info("Node is up")

--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManager.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkManager.scala
@@ -119,6 +119,9 @@ object WorkManager {
           // Any in progress work from the previous incarnation is retried
           ctx.self ! ResetWorkInProgress
       }
+        // Publish events to the system event stream as PublishedEvent after they have been persisted
+        .withEventPublishing(enabled = true)
+
     }
 
 }

--- a/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkResultConsumerActor.scala
+++ b/pekko-sample-distributed-workers-scala/src/main/scala/worker/WorkResultConsumerActor.scala
@@ -1,0 +1,33 @@
+package worker
+
+import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import org.apache.pekko.persistence.typed.PublishedEvent
+import worker.WorkState.{ WorkAccepted, WorkCompleted, WorkInProgressReset, WorkStarted }
+
+object WorkResultConsumerActor {
+  def apply(): Behavior[PublishedEvent] =
+    Behaviors.setup { context =>
+      context.log.info("WorkResultConsumerActor started")
+
+      Behaviors.receiveMessage { message =>
+        handleReceivedEvent(context, message)
+        Behaviors.same
+      }
+    }
+
+  private def handleReceivedEvent(context: ActorContext[PublishedEvent], event: PublishedEvent): Unit = {
+    val actualEvent = event.event
+    event.event match {
+      case WorkInProgressReset =>
+        context.log.info(s"Received published event [${actualEvent.getClass.getCanonicalName}]: {}", event)
+      case WorkCompleted(workId) =>
+        context.log.info(s"Received published event [${actualEvent.getClass.getCanonicalName}]: workId {}", workId)
+      case WorkStarted(workId) =>
+        context.log.info(s"Received published event [${actualEvent.getClass.getCanonicalName}]: workId {}", workId)
+      case WorkAccepted(workId) =>
+        context.log.info(s"Received published event [${actualEvent.getClass.getCanonicalName}]: workId {}", workId)
+      case _ => context.log.warn("Message not supported")
+    }
+  }
+}


### PR DESCRIPTION
A new WorkResultConsumerActor has been added to handle the processing of published events. This actor will receive events and process them accordingly based on their types (WorkAccepted, WorkStarted, etc.). 
Also, the WorkManager.scala file was slightly modified to enable event publishing. 
In Main.scala, a method createWorkResultsConsumer was added to initiate the WorkResultConsumerActor and subscribe it to the event stream. With these changes, all published events will now be handled properly by WorkResultConsumerActor.