### PR TITLE
Add tests for Worker and WorkExecutor classes

### DIFF
--- a/pekko-sample-distributed-workers-scala/src/test/scala/worker/WorkExecutorSpec.scala
+++ b/pekko-sample-distributed-workers-scala/src/test/scala/worker/WorkExecutorSpec.scala
@@ -1,0 +1,21 @@
+package worker
+
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class WorkExecutorSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
+
+  import WorkExecutor._
+
+  "WorkExecutor" must {
+    "correctly compute the square of a number" in {
+      val replyProbe = createTestProbe[Worker.WorkComplete]()
+      val workExecutor = spawn(WorkExecutor())
+
+      workExecutor ! ExecuteWork(3, replyProbe.ref)
+      val response = replyProbe.receiveMessage()
+
+      response.result shouldBe "3 * 3 = 9"
+    }
+  }
+}

--- a/pekko-sample-distributed-workers-scala/src/test/scala/worker/WorkerSpec.scala
+++ b/pekko-sample-distributed-workers-scala/src/test/scala/worker/WorkerSpec.scala
@@ -1,0 +1,38 @@
+package worker
+
+import org.apache.pekko.actor.typed.delivery.ConsumerController
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class WorkerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike {
+
+  "A Worker" must {
+
+    "start work when in idle state" in {
+      val workExecutorProbe = createTestProbe[WorkExecutor.ExecuteWork]()
+      val worker = spawn(Worker(workExecutorFactory = () => Behaviors.monitor(workExecutorProbe.ref, WorkExecutor())))
+      val work = WorkManager.DoWork(Work("TestWork", 1000))
+      val deliveryProbe = createTestProbe[ConsumerController.Confirmed]()
+      val deliveredMessage = Worker.DeliveredMessage(deliveryProbe.ref, work, 1)
+
+      worker ! deliveredMessage
+
+      workExecutorProbe.expectMessageType[WorkExecutor.ExecuteWork]
+    }
+
+    "confirm the work when work is complete" in {
+      val workExecutorProbe = createTestProbe[WorkExecutor.ExecuteWork]()
+      val worker = spawn(Worker(workExecutorFactory = () => Behaviors.monitor(workExecutorProbe.ref, WorkExecutor())))
+      val work = WorkManager.DoWork(Work("TestWork", 1000))
+
+      val deliveryProbe = createTestProbe[ConsumerController.Confirmed]()
+      val deliveredMessage = Worker.DeliveredMessage(deliveryProbe.ref, work, 1)
+
+      worker ! deliveredMessage
+      worker ! Worker.WorkComplete("Successful result")
+
+      deliveryProbe.expectMessageType[ConsumerController.Confirmed]
+    }
+  }
+}


### PR DESCRIPTION
A new test suite for Worker and WorkExecutor has been added. 
The WorkerSpec tests whether work starts when worker is idle and confirms the completion of work. WorkExecutorSpec tests the functionality of the ExecuteWork method by checking whether it correctly computes the square of a given number.