### PR TITLE
upgrade cassandra plugin

### DIFF
--- a/pekko-sample-distributed-workers-scala/build.sbt
+++ b/pekko-sample-distributed-workers-scala/build.sbt
@@ -4,7 +4,7 @@ version := "1.0"
 
 scalaVersion := "2.13.11"
 val pekkoVersion = "1.0.1"
-val cassandraPluginVersion = "0.0.0-1111-f170d7eb-SNAPSHOT"
+val cassandraPluginVersion = "0.0.0-1114-8714f01e-SNAPSHOT"
 val logbackVersion = "1.2.12"
 
 // allow access to snapshots

--- a/pekko-sample-persistence-dc-java/pom.xml
+++ b/pekko-sample-persistence-dc-java/pom.xml
@@ -31,7 +31,7 @@
    <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <pekko.version>1.0.1</pekko.version>
-    <pekko-persistence-cassandra.version>0.0.0-1111-f170d7eb-SNAPSHOT</pekko-persistence-cassandra.version>
+    <pekko-persistence-cassandra.version>0.0.0-1114-8714f01e-SNAPSHOT</pekko-persistence-cassandra.version>
     <pekko-http.version>1.0.0</pekko-http.version>
     <pekko-management.version>1.0.0</pekko-management.version>
   </properties>

--- a/pekko-sample-persistence-dc-scala/build.sbt
+++ b/pekko-sample-persistence-dc-scala/build.sbt
@@ -4,7 +4,7 @@ name := "pekko-sample-replicated-event-sourcing-scala"
 scalaVersion := "2.13.11"
 
 val pekkoVersion = "1.0.1"
-val cassandraPluginVersion = "0.0.0-1111-f170d7eb-SNAPSHOT"
+val cassandraPluginVersion = "0.0.0-1114-8714f01e-SNAPSHOT"
 
 val pekkoHttpVersion = "1.0.0"
 val pekkoClusterManagementVersion = "1.0.0"


### PR DESCRIPTION
this version of cassandra plugin depends on pekko-grpc 1.0.0 release and supports scala 3