### PR TITLE
Adding Apache Pekko gRPC sample in Doc publish.

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -50,6 +50,7 @@ jobs:
           mv docs-gen/pekko-sample-distributed-data-scala/target/paradox/site/main target/nightly-docs/docs/pekko-samples/${{ github.ref_name }}-snapshot/docs/pekko-sample-distributed-data-scala/
           mv docs-gen/pekko-sample-distributed-workers-scala/target/paradox/site/main target/nightly-docs/docs/pekko-samples/${{ github.ref_name }}-snapshot/docs/pekko-sample-distributed-workers-scala/
           mv docs-gen/pekko-sample-kafka-to-sharding-scala/target/paradox/site/main target/nightly-docs/docs/pekko-samples/${{ github.ref_name }}-snapshot/docs/pekko-sample-kafka-to-sharding-scala/
+          mv docs-gen/pekko-sample-grpc-kubernetes-scala/target/paradox/site/main target/nightly-docs/docs/pekko-samples/${{ github.ref_name }}-snapshot/docs/pekko-sample-grpc-kubernetes-scala/
 
       - name: Upload nightly docs
         uses: ./.github/actions/sync-nightlies

--- a/docs-gen/build.sbt
+++ b/docs-gen/build.sbt
@@ -81,3 +81,9 @@ lazy val `pekko-sample-kafka-to-sharding-scala` = project
   .settings(
     name := "Apache Pekko Kafka to Sharding with Scala",
     baseProject := "pekko-sample-kafka-to-sharding-scala")
+
+lazy val `pekko-sample-grpc-kubernetes-scala` = project
+  .enablePlugins(PekkoSamplePlugin)
+  .settings(
+    name := "Apache Pekko gRPC on Kubernetes",
+    baseProject := "pekko-sample-grpc-kubernetes-scala")


### PR DESCRIPTION
Add the pekko-grpc-kubernetes sample in the doc publish job. See: https://github.com/apache/incubator-pekko-grpc/issues/58